### PR TITLE
Bug: Config based directory loads do not work in node_modules context

### DIFF
--- a/lib/schoenberg.js
+++ b/lib/schoenberg.js
@@ -3,9 +3,33 @@
 const manifestFactory = require('./manifest/manifest');
 const config = require('config');
 const _ = require('lodash');
+const path = require('path');
+const stack = require('callsite');
+
+const getTraceIndex = function getTraceIndex(index) {
+  if (index > 0) {
+    return index - 1;
+  }
+  return 0;
+};
+
+const getResolvedPath = function getResolvedPath(value) {
+  // Use callsite to resolve path from calling script.
+  const base = require.resolve('../../../');
+  const stackTrace = stack().reverse();
+  let traceIndex = stackTrace.findIndex(
+    trace => trace.getFileName() === base
+  );
+  traceIndex = getTraceIndex(traceIndex);
+  return path.resolve(
+    path.dirname(stackTrace[traceIndex].getFileName()),
+    value
+  );
+};
 
 module.exports = function schoenberg(semverishSource, configs, nameSpace) {
   let tmpConfig;
+  let tmpSource;
   if (!configs) {
     if (_.has(config, 'semverist')) {
       tmpConfig = config.get('semverist');
@@ -18,6 +42,13 @@ module.exports = function schoenberg(semverishSource, configs, nameSpace) {
     tmpConfig = _.cloneDeep(configs);
   }
 
+  if (!semverishSource) {
+    tmpSource = getResolvedPath(tmpConfig[nameSpace].semverishObjectLocation);
+  }
+  else {
+    tmpSource = semverishSource;
+  }
+
   return manifestFactory(
       'composer',
       nameSpace,
@@ -25,7 +56,7 @@ module.exports = function schoenberg(semverishSource, configs, nameSpace) {
     )
     .then(ManifestClass => Promise.all(
       [
-        ManifestClass.createConverter(semverishSource),
+        ManifestClass.createConverter(tmpSource),
         ManifestClass
       ]))
     .then((manifestIngredients) => {


### PR DESCRIPTION
If a module was using the semverist and relied on config based directory locations it would not load correctly. This resolves that and allows the location of the directory to be relative to the implementing module's root.