### PR TITLE
fix(package): Reduced klaw sync back down, it will be a breaking change.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "callsite": "^1.0.0",
     "config": "^1.25.1",
     "fs-extra": "^3.0.0",
-    "klaw-sync": "2.1.0",
+    "klaw-sync": "1.1.2",
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
     "molotov": "0.0.2",


### PR DESCRIPTION
klaw sync upgrade posed no problem for tests but broke semverist users depending on old filtering technique- which i think is an issue we need to solve, but was also brought about by the upgrade, easiest path forward is to reverse course.