### PR TITLE
fix(configLoader): Correctly load passed in config

### DIFF
--- a/lib/configLoader.js
+++ b/lib/configLoader.js
@@ -101,14 +101,16 @@ function configLoader(configNameSpace, configs) {
   // Name spaces allow for seperate individualized configurations for the
   // semverist in the same config organized by named key.
   if (tmpConfigNameSpace) {
-    if (_.has(config, 'semverist')) {
+    if (config.has(`semverist.${tmpConfigNameSpace}`)) {
       // If the key doesn't exist this will throw.
       tmpNameSpaceConfig = config.get(`semverist.${tmpConfigNameSpace}`);
       tmpNameSpaceConfig = _.assignIn({}, totallyNew, tmpNameSpaceConfig);
     }
-    else {
-      if (!_.has(totallyNew, tmpConfigNameSpace)) throw new Error('Name space does not exist in passed configs.');
+    else if (_.has(totallyNew, tmpConfigNameSpace)) {
       tmpNameSpaceConfig = _.get(totallyNew, tmpConfigNameSpace);
+    }
+    else {
+      throw new Error('Name space does not exist in passed configs.');
     }
 
     // Now we can extend the module defaults with our nameSpace config.


### PR DESCRIPTION
If the `semverist` config object existed but the passed in config was not already part of the config object the configLoader would fail.

This is undesirable when semverist is used as a dependency of a dependency.